### PR TITLE
Reimplement cache interface for infrastructure cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: rust
+dist: xenial
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+before_install:
+  - sudo apt-get install -y libgnutls28-dev
+  - git clone -b v2.7.2 https://github.com/cz-nic/knot.git
+  - cd knot
+  - autoreconf -fi
+  - ./configure --disable-static --disable-fastparser --disable-documentation --disable-daemon --disable-utilities --with-lmdb=no
+  - sudo make -j2 install
+  - sudo ldconfig
+notifications:
+  email:
+    on_success: never
+    on_failure: never

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clockpro-cache"
+version = "0.1.6"
+source = "git+https://github.com/jedisct1/rust-clockpro-cache?rev=cea96d3073d48379fe5ceb87ca7c62d6927472de#cea96d3073d48379fe5ceb87ca7c62d6927472de"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +347,7 @@ name = "kres"
 version = "0.1.4"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clockpro-cache 0.1.6 (git+https://github.com/jedisct1/rust-clockpro-cache?rev=cea96d3073d48379fe5ceb87ca7c62d6927472de)",
  "dnssector 0.1.3 (git+https://github.com/jedisct1/dnssector?rev=ef7625bbc0f97518eadc5878e5ed476fa54c19ae)",
  "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "kres-sys 0.1.4",
@@ -661,6 +671,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "smallvec"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chomp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f74ad218e66339b11fd23f693fb8f1d621e80ba6ac218297be26073365d163d"
 "checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum clockpro-cache 0.1.6 (git+https://github.com/jedisct1/rust-clockpro-cache?rev=cea96d3073d48379fe5ceb87ca7c62d6927472de)" = "<none>"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
@@ -947,6 +963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "88aea073965ab29f6edb5493faf96ad662fb18aa9eeb186a3b7057951605ed15"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,11 +164,12 @@ dependencies = [
 
 [[package]]
 name = "clockpro-cache"
-version = "0.1.6"
-source = "git+https://github.com/jedisct1/rust-clockpro-cache?rev=cea96d3073d48379fe5ceb87ca7c62d6927472de#cea96d3073d48379fe5ceb87ca7c62d6927472de"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsafe_unwrap 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -347,7 +348,7 @@ name = "kres"
 version = "0.1.4"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "clockpro-cache 0.1.6 (git+https://github.com/jedisct1/rust-clockpro-cache?rev=cea96d3073d48379fe5ceb87ca7c62d6927472de)",
+ "clockpro-cache 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dnssector 0.1.3 (git+https://github.com/jedisct1/dnssector?rev=ef7625bbc0f97518eadc5878e5ed476fa54c19ae)",
  "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "kres-sys 0.1.4",
@@ -806,6 +807,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe_unwrap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,7 +909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chomp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f74ad218e66339b11fd23f693fb8f1d621e80ba6ac218297be26073365d163d"
 "checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum clockpro-cache 0.1.6 (git+https://github.com/jedisct1/rust-clockpro-cache?rev=cea96d3073d48379fe5ceb87ca7c62d6927472de)" = "<none>"
+"checksum clockpro-cache 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "009a9db3878be5072ccb5b5c64d403bdf69c844119fc46fe0c49e0b80e37f25f"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
@@ -981,6 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum unsafe_unwrap 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1230ec65f13e0f9b28d789da20d2d419511893ea9dac2c1f4ef67b8b14e5da80"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/crates/kres-sys/build.rs
+++ b/crates/kres-sys/build.rs
@@ -18,7 +18,18 @@ fn main() {
 
     let bindings = bindgen::Builder::default()
         .header("resolve.h")
+        .clang_args(["-I", "src/knot-resolver"].iter())
+        .header("src/knot-resolver/lib/cache/api.h")
+        .opaque_type("knot_mm_t")
+        .opaque_type("kr_cdb_api")
+        .whitelist_type("knot_rdata_t")
+        .whitelist_type("knot_rdataset_t")
+        .whitelist_type("knot_mm_t")
+        .whitelist_type("kr_cache")
+        .whitelist_type("kr_cache_p")
+        .whitelist_type("ranked_rr_array_entry_t")
         .whitelist_function("lkr_.*")
+        .whitelist_function("knot_rdataset_add")
         .rustified_enum("lkr_state")
         .raw_line("#[allow(bad_style)]")
         .generate()
@@ -58,6 +69,7 @@ fn main() {
             .current_dir(&libkres_src_dir)
             .arg("lib")
             .arg("BUILDMODE=static")
+            .arg("LIBRARY_ONLY=yes")
             .status()
             .expect("failed to build libkres");
 

--- a/crates/kres-sys/build.rs
+++ b/crates/kres-sys/build.rs
@@ -65,11 +65,25 @@ fn main() {
             libkres_src_dir.display()
         );
 
+        let compiler = cc::Build::new().get_compiler();
+        let mut cflags = compiler
+            .args()
+            .iter()
+            .map(|s| s.to_str().unwrap())
+            .collect::<Vec<_>>();
+
+        // Disable IPv6 unfairness
+        cflags.push("-DFAVOUR_IPV6=0");
+
+        // Build
         Command::new("make")
             .current_dir(&libkres_src_dir)
             .arg("lib")
+            .arg("V=1")
             .arg("BUILDMODE=static")
             .arg("LIBRARY_ONLY=yes")
+            .env("CC", compiler.path())
+            .env("CFLAGS", cflags.join(" "))
             .status()
             .expect("failed to build libkres");
 

--- a/crates/kres-sys/resolve.c
+++ b/crates/kres-sys/resolve.c
@@ -107,7 +107,6 @@ struct lkr_context *lkr_context_new()
 	lkr_root_hint(ctx, (const uint8_t *) "\xc0\xcb\xe6\x0a", 4);
 	/* Default options */
 	resolver->options.NO_0X20 = true;
-	resolver->options.NO_IPV6 = true;
 	return ctx;
 }
 
@@ -286,7 +285,8 @@ static size_t select_infra_records(ranked_rr_array_t *arr, const ranked_rr_array
 			continue;
 
 		// Only accept infrastructure records
-		if (!is_infra_type(entry->rr->type) || entry->to_wire) {
+		const uint16_t rr_type = entry->rr->type;
+		if (!is_infra_type(rr_type) || (entry->to_wire && rr_type != KNOT_RRTYPE_NS)) {
 			continue;
 		}
 

--- a/crates/kres-sys/resolve.c
+++ b/crates/kres-sys/resolve.c
@@ -7,7 +7,6 @@
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #include "lib/resolve.h"
 #include "lib/dnssec/ta.h"
-#include "lib/cache/cdb_lmdb.h"
 #include "contrib/ucw/mempool.h"
 #pragma GCC diagnostic pop
 #include "resolve.h"
@@ -112,10 +111,10 @@ struct lkr_context *lkr_context_new()
 	return ctx;
 }
 
-int lkr_cache_open(struct lkr_context *ctx, const char *path, size_t max_bytes)
+int lkr_cache_open(struct lkr_context *ctx, void *cache_ptr)
 {
-	struct kr_cdb_opts opts = { path, max_bytes };
-	return kr_cache_open(&ctx->resolver.cache, kr_cdb_lmdb(), &opts, &ctx->pool);
+	ctx->resolver.cache.db = (knot_db_t *)cache_ptr;
+	return 0;
 }
 
 void lkr_context_free(struct lkr_context *ctx)
@@ -149,9 +148,6 @@ struct lkr_request *lkr_request_new(struct lkr_context *ctx)
 	}
 
 	int ret = kr_resolve_begin(&req->req, &ctx->resolver, req->req.answer);
-
-	/* Make sure there's no open cache transaction as they can't span threads */
-	kr_cache_sync(&req->req.ctx->cache);
 
 	if (ret == KR_STATE_FAIL) {
 		lkr_request_free(req);
@@ -194,12 +190,7 @@ enum lkr_state lkr_consume(struct lkr_request *req, const struct sockaddr *addr,
 		req->req.qsource.size = first_query_size;
 	}
 
-	ret = kr_resolve_consume(&req->req, addr, packet);
-
-	/* Make sure there's no open cache transaction as they can't span threads */
-	kr_cache_sync(&req->req.ctx->cache);
-
-	return (enum lkr_state) ret;
+	return (enum lkr_state) kr_resolve_consume(&req->req, addr, packet);
 }
 
 enum lkr_state lkr_produce(struct lkr_request *req, struct sockaddr *addrs[], size_t addrs_len, uint8_t *data, size_t *len, _Bool is_stream)
@@ -211,17 +202,12 @@ enum lkr_state lkr_produce(struct lkr_request *req, struct sockaddr *addrs[], si
 
 	/* Convert linear array into the array of struct sockaddr pointers */
 	if (!addr_list) {
-		/* Make sure there's no open cache transaction as they can't span threads */
-		kr_cache_sync(&req->req.ctx->cache);
 		*len = packet->size;
 		return (enum lkr_state) res;
 	}
 
 	/* TODO: This will need to happen before each send when the destination address is known */
 	int ret = kr_resolve_checkout(&req->req, NULL, addr_list, sock_type, packet);
-
-	/* Make sure there's no open cache transaction as they can't span threads */
-	kr_cache_sync(&req->req.ctx->cache);
 
 	if (ret != 0) {
 		*len = packet->size;
@@ -245,9 +231,6 @@ size_t lkr_finish(struct lkr_request *req, enum lkr_state state)
 {
 	(void) kr_resolve_finish(&req->req, state);
 
-	/* Make sure there's no open cache transaction as they can't span threads */
-	kr_cache_sync(&req->req.ctx->cache);
-
 	return req->req.answer->size;
 }
 
@@ -262,7 +245,88 @@ size_t lkr_write_answer(struct lkr_request *req, uint8_t *dst, size_t max_bytes)
 	return answer->size;
 }
 
+const uint8_t *lkr_current_zone_cut(struct lkr_request *req)
+{
+	if (kr_rplan_empty(&req->req.rplan)) {
+		return NULL;
+	}
+
+	struct kr_query *current = array_tail(req->req.rplan.pending);
+	if (current == NULL) {
+		return NULL;
+	}
+
+	return (const uint8_t *)current->zone_cut.name;
+}
+
+/// Returns true if the type is an infrastructure type.
+static bool is_infra_type(uint16_t rr_type) {
+	switch (rr_type) {
+	case KNOT_RRTYPE_NS:
+	case KNOT_RRTYPE_DS:
+	case KNOT_RRTYPE_DNSKEY:
+	case KNOT_RRTYPE_A:
+	case KNOT_RRTYPE_AAAA:
+		return true;
+	default:
+		return false;
+	}
+}
+
+// Select infrastructure records accepted from an upstream response
+static size_t select_infra_records(ranked_rr_array_t *arr, const ranked_rr_array_entry_t *dst[], size_t off, size_t max_count)
+{
+	for (size_t i = 0; i < arr->len; ++i) {
+		ranked_rr_array_entry_t *entry = arr->at[i];
+
+		if (off >= max_count)
+			break;
+
+		if (entry->cached)
+			continue;
+
+		// Only accept infrastructure records
+		if (!is_infra_type(entry->rr->type) || entry->to_wire) {
+			continue;
+		}
+
+		// Accept any that's valid
+		if (kr_rank_test(entry->rank, KR_RANK_INITIAL)
+			|| kr_rank_test(entry->rank, KR_RANK_BOGUS)
+			|| kr_rank_test(entry->rank, KR_RANK_MISMATCH)
+			|| kr_rank_test(entry->rank, KR_RANK_MISSING)) {
+			continue;
+		}
+
+		entry->cached = true;
+		dst[off] = entry;
+		off += 1;
+	}
+
+	return off;
+}
+
+size_t lkr_accepted_records(struct lkr_request *req, const ranked_rr_array_entry_t *dst[], size_t max_count) {
+
+	size_t off = 0;
+	off = select_infra_records(&req->req.answ_selected, dst, off, max_count);
+	off = select_infra_records(&req->req.auth_selected, dst, off, max_count);
+	off = select_infra_records(&req->req.add_selected, dst, off, max_count);
+
+	return off;
+}
+
 int lkr_sockaddr_len(struct sockaddr *sa)
 {
 	return kr_sockaddr_len(sa);
+}
+
+int lkr_dname_len(const uint8_t *dname)
+{
+	return knot_dname_size((const knot_dname_t *)dname);
+}
+
+knot_rdata_t *lkr_rdata_next(knot_rdata_t *rdata)
+{
+	return knot_rdataset_next(rdata);
 }

--- a/crates/kres-sys/resolve.h
+++ b/crates/kres-sys/resolve.h
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <libknot/rdataset.h>
 
 /* Reexported layer state from libkres */
 enum lkr_state {
@@ -15,6 +16,7 @@ enum lkr_state {
 struct sockaddr;
 struct lkr_context_t;
 struct lkr_request;
+struct ranked_rr_array_entry;
 
 /* High level interfaces abstracted from the engine */
 
@@ -22,7 +24,7 @@ struct lkr_context *lkr_context_new();
 void lkr_context_free(struct lkr_context *ctx);
 int lkr_module_load(struct lkr_context *ctx, const char *name);
 int lkr_module_unload(struct lkr_context *ctx, const char *name);
-int lkr_cache_open(struct lkr_context *ctx, const char *path, size_t max_bytes);
+int lkr_cache_open(struct lkr_context *ctx, void *cache_ptr);
 int lkr_root_hint(struct lkr_context *ctx, const uint8_t *data, size_t len);
 int lkr_trust_anchor(struct lkr_context *ctx, const uint8_t *data, size_t len);
 void lkr_verbose(struct lkr_context *ctx, bool val);
@@ -33,4 +35,8 @@ enum lkr_state lkr_consume(struct lkr_request *req, const struct sockaddr *addr,
 enum lkr_state lkr_produce(struct lkr_request *req, struct sockaddr *addrs[], size_t addrs_len, uint8_t *data, size_t *len, _Bool is_stream);
 size_t lkr_finish(struct lkr_request *req, enum lkr_state state);
 size_t lkr_write_answer(struct lkr_request *req, uint8_t *dst, size_t max_bytes);
+const uint8_t *lkr_current_zone_cut(struct lkr_request *req);
+size_t lkr_accepted_records(struct lkr_request *req, const struct ranked_rr_array_entry *dst[], size_t max_count);
 int lkr_sockaddr_len(struct sockaddr *sa);
+int lkr_dname_len(const uint8_t *dname);
+knot_rdata_t *lkr_rdata_next(knot_rdata_t *rdata);

--- a/crates/kres-sys/src/lib.rs
+++ b/crates/kres-sys/src/lib.rs
@@ -3,16 +3,7 @@
 //! including cache and DNSSEC validation. It doesn't require a specific I/O model and instead provides
 //! a generic interface for pushing/pulling DNS messages until the request is satisfied.
 //!
-//! The interface provided implements a minimal subset of operations from the engine:
-//!
-//! * `struct kr_context` is wrapped by [Context](struct.Context.html). Functions from libkres that
-//! operate on `struct kr_context` are accessed using methods on [Context](struct.Context.html).
-//! The context implements lock guards for all FFI calls on context, and all FFI calls on request
-//! that borrows given context.
-//!
-//! * `struct kr_request` is wrapped by [Request](struct.Request.html). Methods on
-//! [Request](struct.Request.html) are used to safely access the fields of `struct kr_request`.
-//! Methods that wrap FFI calls lock request and its context for thread-safe access.
+//! The package exports Rust bindings for libkres core library, and provides a minimal shim for its cache interface.
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![cfg_attr(
@@ -20,5 +11,167 @@
     allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)
 )]
 
+use std::os::raw::{c_int, c_void};
+
 // Wrapped C library
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+/// Cache entry with wire format RDATA.
+#[derive(Clone, Debug)]
+pub struct CacheEntry {
+    /// Rank of the entry (opaque value representing trustworthiness)
+    pub rank: u8,
+    /// Remaining TTL of the cache entry
+    pub ttl: u32,
+    /// Vec of RDATA in wire format.
+    pub rdata: Vec<Vec<u8>>,
+}
+
+impl CacheEntry {
+    pub fn new(ttl: u32, rank: u8, rdata: Vec<Vec<u8>>) -> Self {
+        Self { ttl, rank, rdata }
+    }
+}
+
+/// Cache trait for name/type lookups.
+pub trait Cache {
+    fn get(&mut self, name: &[u8], rr_type: u16) -> Option<CacheEntry>;
+    fn insert(&mut self, name: &[u8], rr_type: u16, entry: CacheEntry);
+}
+
+// Reimplemented opaque `knot_db_t` using a boxed trait object.
+pub struct CacheState {
+    current: Option<CacheEntry>,
+    inner: Box<Cache>,
+}
+
+impl CacheState {
+    /// Create an empty state.
+    pub fn new(inner: Box<Cache>) -> Self {
+        Self {
+            current: None,
+            inner,
+        }
+    }
+
+    /// Return mutable reference to cache,
+    pub fn as_cache_mut(&mut self) -> &mut Box<Cache> {
+        &mut self.inner
+    }
+}
+
+// Unsafe conversion from mutable pointer
+impl From<*mut kr_cache> for &'static mut CacheState {
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn from(ptr: *mut kr_cache) -> &'static mut CacheState {
+        unsafe {
+            let state_ptr = (&mut *ptr).db as *mut CacheState;
+            &mut *state_ptr
+        }
+    }
+}
+
+/// Parse dname in wireformat into a slice of bytes.
+pub unsafe fn kr_dname_to_slice(name: *const u8) -> &'static [u8] {
+    let len = lkr_dname_len(name);
+    if len < 0 || len > 255 {
+        &[]
+    } else {
+        std::slice::from_raw_parts(name, len as usize)
+    }
+}
+
+// Reimplement record retrieval. It must be followed by materialize if succeeds.
+#[no_mangle]
+pub extern "C" fn kr_cache_peek_exact(
+    cache: *mut kr_cache,
+    name: *const u8,
+    rr_type: u16,
+    peek: *mut kr_cache_p,
+) -> c_int {
+    assert!(!cache.is_null());
+    assert!(!name.is_null());
+    assert!(!peek.is_null());
+
+    // Unwrap domain name in wire format
+    let name = unsafe { kr_dname_to_slice(name) };
+
+    // Get current entry in an internal buffer
+    let state: &mut CacheState = cache.into();
+    match state.as_cache_mut().get(name, rr_type) {
+        Some(entry) => {
+            if peek.is_null() {
+                return -2;
+            }
+            // Update TTL and rank in the provided structure
+            let peek = unsafe { &mut *peek };
+            peek.ttl = entry.ttl;
+            peek.rank = entry.rank;
+            // The peek doesn't take ownership of the data, so we store it in current state
+            // this means, that a peek state lives only until the next peek.
+            // TODO: https://github.com/rust-lang/rust-bindgen/issues/784
+            peek.__bindgen_anon_1.raw_data = cache as *mut c_void;
+            state.current.replace(entry);
+            0
+        }
+        None => -2,
+    }
+}
+
+// Reimplement record conversion to `knot_rdataset_t`.
+#[no_mangle]
+extern "C" fn kr_cache_materialize(
+    dst: *mut knot_rdataset_t,
+    peek: *mut kr_cache_p,
+    pool: *mut knot_mm_t,
+) -> c_int {
+    assert!(!dst.is_null());
+    assert!(!peek.is_null());
+
+    // See `kr_cache_peek_exact` for explanation
+    let peek = unsafe { &mut *peek };
+    let state = peek.__bindgen_anon_1.raw_data as *mut kr_cache;
+    if state.is_null() {
+        return -2;
+    }
+
+    // Convert RDATA as vec of slices into the `dst`
+    let state: &mut CacheState = state.into();
+    if let Some(entry) = state.current.take() {
+        for rd in entry.rdata {
+            // See https://github.com/CZ-NIC/knot/blob/f83685b822418cb6317f23e81686d78655530a03/src/libknot/rdata.h#L68
+            let mut buf = vec![0u8; std::mem::size_of::<u16>() + rd.len() + (rd.len() & 1)];
+            let mut rdata = unsafe { &mut *(buf.as_mut_ptr() as *mut knot_rdata_t) };
+            rdata.len = rd.len() as u16;
+            let slice = unsafe { rdata.data.as_mut_slice(rd.len()) };
+            slice.copy_from_slice(&rd);
+            // Add buffer to rdataset
+            let ret = unsafe { knot_rdataset_add(dst, rdata, pool) };
+            if ret < 0 {
+                return ret;
+            }
+        }
+
+        // Success
+        return 0;
+    }
+
+    -2
+}
+
+#[no_mangle]
+extern "C" fn kr_cache_ttl(
+    peek: *mut kr_cache_p,
+    _query: *mut c_void,
+    _name: *const u8,
+    _rr_type: u16,
+) -> c_int {
+    assert!(!peek.is_null());
+    unsafe { &*peek }.ttl as c_int
+}
+
+// No-op implementations just to provide the symbols.
+#[no_mangle]
+extern "C" fn kr_cache_sync(_cache: *mut kr_cache) -> c_int {
+    0
+}

--- a/crates/kres/Cargo.toml
+++ b/crates/kres/Cargo.toml
@@ -18,7 +18,7 @@ socket2 = "0.3"
 jemallocator = { version = "0.1", optional = true }
 parking_lot = { version = "0.7" }
 kres-sys = { path = "../kres-sys", features = ["static"]}
-clockpro-cache = {git = "https://github.com/jedisct1/rust-clockpro-cache", rev = "cea96d3073d48379fe5ceb87ca7c62d6927472de", optional = true}
+clockpro-cache = { version = "0.1.7", optional = true}
 
 [dev-dependencies]
 dnssector = { git = "https://github.com/jedisct1/dnssector", rev = "ef7625bbc0f97518eadc5878e5ed476fa54c19ae" }

--- a/crates/kres/Cargo.toml
+++ b/crates/kres/Cargo.toml
@@ -18,10 +18,12 @@ socket2 = "0.3"
 jemallocator = { version = "0.1", optional = true }
 parking_lot = { version = "0.7" }
 kres-sys = { path = "../kres-sys", features = ["static"]}
+clockpro-cache = {git = "https://github.com/jedisct1/rust-clockpro-cache", rev = "cea96d3073d48379fe5ceb87ca7c62d6927472de", optional = true}
 
 [dev-dependencies]
 dnssector = { git = "https://github.com/jedisct1/dnssector", rev = "ef7625bbc0f97518eadc5878e5ed476fa54c19ae" }
 
 [features]
+cache = ["clockpro-cache"]
 jemalloc = ["jemallocator"]
 default = []

--- a/crates/kres/src/cache.rs
+++ b/crates/kres/src/cache.rs
@@ -1,0 +1,70 @@
+use clockpro_cache::*;
+use kres_sys;
+use std::io::{Error, ErrorKind, Result};
+use std::ops::{Add, Sub};
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+struct DefaultCacheEntry {
+    inception: Instant,
+    inner: kres_sys::CacheEntry,
+}
+
+impl DefaultCacheEntry {
+    fn is_expired(&self) -> bool {
+        let now = Instant::now();
+        now > self
+            .inception
+            .add(Duration::from_secs(u64::from(self.inner.ttl)))
+    }
+
+    fn elapsed(&self) -> u32 {
+        let now = Instant::now();
+        now.sub(self.inception).as_secs() as u32
+    }
+}
+
+/// Default cache implementation (CLOCK-PRO).
+pub struct DefaultCache {
+    inner: ClockProCache<(Vec<u8>, u16), DefaultCacheEntry>,
+}
+
+impl DefaultCache {
+    pub fn new(capacity: usize) -> Result<Self> {
+        let inner = ClockProCache::new(capacity)
+            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+        Ok(Self { inner })
+    }
+}
+
+impl kres_sys::Cache for DefaultCache {
+    fn get(&mut self, name: &[u8], rr_type: u16) -> Option<kres_sys::CacheEntry> {
+        let key = (name.to_vec(), rr_type);
+        match self.inner.get(&key) {
+            Some(ref entry) => {
+                // Check if the entry is fresh
+                if entry.is_expired() {
+                    return None;
+                }
+                // Return entry with decayed TTL
+                let elapsed = entry.elapsed();
+                Some(kres_sys::CacheEntry {
+                    ttl: entry.inner.ttl.saturating_sub(elapsed),
+                    rank: entry.inner.rank,
+                    rdata: entry.inner.rdata.clone(),
+                })
+            }
+            None => None,
+        }
+    }
+
+    fn insert(&mut self, name: &[u8], rr_type: u16, entry: kres_sys::CacheEntry) {
+        self.inner.insert(
+            (name.to_vec(), rr_type),
+            DefaultCacheEntry {
+                inception: Instant::now(),
+                inner: entry,
+            },
+        );
+    }
+}


### PR DESCRIPTION
The libkres is now compiled with `LIBRARY_ONLY`, which disables
built-in cache layers and lmdb.

The `kres-sys` crate now provides symbols for:

* `kr_cache_peek_exact`
* `kr_cache_materialize`
* `kr_cache_ttl`
* `kr_cache_sync`

These symbols are used in zonecut.c directly for zone cut discovery.
These are implemented as shim to an optional generic cache implementation
provided by `CacheState`. The shim takes care of conversions from Rust native
types to internal types (ranked_rr_array_t, knot_rdataset_t, knot_rdata_t).

This cache is only used for infrastructure records, response caching
should be implemented by caller before calling this library.